### PR TITLE
Param sets & Null Setting Error handling

### DIFF
--- a/IntuneCustomCompliance/IntuneCustomCompliance.psm1
+++ b/IntuneCustomCompliance/IntuneCustomCompliance.psm1
@@ -154,8 +154,19 @@ function New-IntuneCustomComplianceRuleSet {
 .PARAMETER Description
     Remediation description detail that gets displayed in the Company Portal when a device is noncompliant to a setting. This information is intended to help users understand the remediation options to bring a device to a compliant state.
 
+.INPUTS
+
+Array or Hashtable. Piping results to -QueryResult paramter set
+
+.OUTPUTS
+
+System.Collections.Hashtable. Converted into JSON format for easy export
+
 .EXAMPLE
      New-IntuneCustomComplianceRuleSet -QueryResult $Output -PropertyName 'Name' -PropertyValue 'Action' -Operator 'IsEquals' -DataType 'String' -Operand 'ComplianceValue' -MoreInfoURL $uri -Title $title
+
+.EXAMPLE
+     New-IntuneCustomComplianceRuleSet -CustomQueryResult $Output -Operator 'IsEquals' -DataType 'String' -Operand 'ComplianceValue' -MoreInfoURL $uri -Title $title
 
 .PARAMETER Destination
     Outputs array of Key/Value pairs to single JSON file

--- a/IntuneCustomCompliance/IntuneCustomCompliance.psm1
+++ b/IntuneCustomCompliance/IntuneCustomCompliance.psm1
@@ -131,10 +131,10 @@ function New-IntuneCustomComplianceRuleSet {
     Variable of stored query result
 
 .PARAMETER PropertyName
-    Setting Key column identified as property in query
+    Setting Key column identified as property in query. Applicable to QueryResult parameter set only
 
 .PARAMETER PropertyValue
-    Setting Value column identified as property in query
+    Setting Value column identified as property in query. Applicable to QueryResult parameter set only
 
 .PARAMETER Operator
     Represents a specific action that is used to build a compliance rule. For options, see the following list of supported operators.

--- a/IntuneCustomCompliance/IntuneCustomCompliance.psm1
+++ b/IntuneCustomCompliance/IntuneCustomCompliance.psm1
@@ -266,8 +266,21 @@ System.Collections.Hashtable. Converted into JSON format for easy export
                     Title       = $Title
                     Description = $Description
                 }
-                $iccs = New-IntuneCustomComplianceSetting @params
-                $ruleSet.Add($iccs) | Out-Null
+                try {
+                    if (($null -ne $params.SettingName) -and ($null -ne $params.Operand)) {
+                        $iccs = New-IntuneCustomComplianceSetting @params
+                        $ruleSet.Add($iccs) | Out-Null
+                    }
+                    else {
+                        (($null -eq $params.SettingName) -or ($null -eq $params.Operand))
+                        Write-Host 'Setting skipped because of Null value in Name or Operand'
+                    }
+
+                }
+                catch {
+                    { throw }
+                }
+
             }
             if (!$Destination) {
                 Write-Warning "To export, use '-Destination' parameter"

--- a/IntuneCustomCompliance/IntuneCustomCompliance.psm1
+++ b/IntuneCustomCompliance/IntuneCustomCompliance.psm1
@@ -231,14 +231,15 @@ function New-IntuneCustomComplianceRuleSet {
             })]
         [string]$Destination
     )
+    begin {
+        if ($QueryResultHash) {
+            $QueryResultHash.GetEnumerator() | ForEach-Object { $arr += [pscustomobject]@{PropertyName = $_.Name ; PropertyValue = $_.Value }; }
+            $QueryResult = $arr
+        }
+    }
     process {
         if ($PSCmdlet.ShouldProcess("Creating ArrayList from individual Custom Compliance Settings", $PropertyName, $PropertyValue)) {
             $ruleSet = [System.Collections.ArrayList]@()
-            if ($QueryResultHash) {
-                $QueryResultHash.GetEnumerator() | ForEach-Object { $arr += [pscustomobject]@{PropertyName = $_.Name ; PropertyValue = $_.Value }; }
-                $QueryResult = $arr
-            }
-
             foreach ($rule in $QueryResult) {
                 $params = @{
                     SettingName = $rule.$PropertyName

--- a/IntuneCustomCompliance/IntuneCustomCompliance.psm1
+++ b/IntuneCustomCompliance/IntuneCustomCompliance.psm1
@@ -171,14 +171,12 @@ function New-IntuneCustomComplianceRuleSet {
 
         [Parameter(Mandatory = $true, Position = 0, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'hash')]
         [ValidateNotNullOrEmpty()]
-        [hashtable]$CustomQueryResult, # accept hashtable as input
+        [hashtable]$CustomQueryResult,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'array')]
-        #[Parameter(Mandatory = $false, ParameterSetName = 'hash')]
         [string]$PropertyName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'array')]
-        #[Parameter(Mandatory = $false, ParameterSetName = 'hash')]
         [ValidateNotNullOrEmpty()]
         [string]$PropertyValue,
 

--- a/IntuneCustomCompliance/IntuneCustomCompliance.psm1
+++ b/IntuneCustomCompliance/IntuneCustomCompliance.psm1
@@ -165,29 +165,60 @@ function New-IntuneCustomComplianceRuleSet {
 #>
     [CmdletBinding(SupportsShouldProcess)]
     param (
-        [Parameter(Mandatory = $true, ValueFromPipeline)]
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true, ParameterSetName = 'array')]
         [ValidateNotNullOrEmpty()]
         [array]$QueryResult,
+
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipelineByPropertyName = $true, ParameterSetName = 'hash')]
+        [ValidateNotNullOrEmpty()]
+        [hashtable]$QueryResultHash, # accept hashtable as input
+
+        [Parameter(ParameterSetName = 'array')]
+        [Parameter(ParameterSetName = 'hash')]
         [Parameter(ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
         [string]$PropertyName,
+
+        [Parameter(ParameterSetName = 'array')]
+        [Parameter(ParameterSetName = 'hash')]
         [Parameter(Mandatory = $true, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
         [string]$PropertyValue,
+
+        [Parameter(ParameterSetName = 'array')]
+        [Parameter(ParameterSetName = 'hash')]
         [Parameter(Mandatory = $true)]
         [ValidateSet('IsEquals', 'NotEquals', 'GreaterThan', 'GreaterEquals', 'LessThan', 'LessEquals')]
         [string]$Operator,
+
+        [Parameter(ParameterSetName = 'array')]
+        [Parameter(ParameterSetName = 'hash')]
         [Parameter(Mandatory = $true)]
         [ValidateSet('Boolean', 'Int64', 'Double', 'String', 'DateTime', 'Version')]
         [string]$DataType,
+
+        [Parameter(ParameterSetName = 'array')]
+        [Parameter(ParameterSetName = 'hash')]
         [Parameter(Mandatory = $false)]
         [string]$MoreInfoURL,
+
+        [Parameter(ParameterSetName = 'array')]
+        [Parameter(ParameterSetName = 'hash')]
         [Parameter(Mandatory = $false)]
         [string]$Language = 'en_US',
+
+        [Parameter(ParameterSetName = 'array')]
+        [Parameter(ParameterSetName = 'hash')]
         [Parameter(Mandatory = $false)]
         [string]$Title,
+
+        [Parameter(ParameterSetName = 'array')]
+        [Parameter(ParameterSetName = 'hash')]
         [Parameter(Mandatory = $false)]
         [string]$Description,
+
+        [Parameter(ParameterSetName = 'array')]
+        [Parameter(ParameterSetName = 'hash')]
         [Parameter(Mandatory = $false)]
         [System.IO.FileInfo]
         [ValidateScript({
@@ -199,11 +230,15 @@ function New-IntuneCustomComplianceRuleSet {
                 }
             })]
         [string]$Destination
-
     )
     process {
         if ($PSCmdlet.ShouldProcess("Creating ArrayList from individual Custom Compliance Settings", $PropertyName, $PropertyValue)) {
             $ruleSet = [System.Collections.ArrayList]@()
+            if ($QueryResultHash) {
+                $QueryResultHash.GetEnumerator() | ForEach-Object { $arr += [pscustomobject]@{PropertyName = $_.Name ; PropertyValue = $_.Value }; }
+                $QueryResult = $arr
+            }
+
             foreach ($rule in $QueryResult) {
                 $params = @{
                     SettingName = $rule.$PropertyName

--- a/IntuneCustomCompliance/IntuneCustomCompliance.psm1
+++ b/IntuneCustomCompliance/IntuneCustomCompliance.psm1
@@ -249,28 +249,22 @@ System.Collections.Hashtable. Converted into JSON format for easy export
             $ruleSet = [System.Collections.ArrayList]@()
             foreach ($rule in $QueryResult) {
                 if ($CustomQueryResult) {
-                    $params = @{
-                        SettingName = $rule.PropertyName
-                        Operator    = $Operator
-                        DataType    = $DataType
-                        Operand     = $rule.PropertyValue
-                        MoreInfoURL = $MoreInfoURL
-                        Language    = $Language
-                        Title       = $Title
-                        Description = $Description
-                    }
+                    $k = $rule.PropertyName
+                    $v = $rule.PropertyValue
                 }
                 else {
-                    $params = @{
-                        SettingName = $rule.$PropertyName
-                        Operator    = $Operator
-                        DataType    = $DataType
-                        Operand     = $rule.$PropertyValue
-                        MoreInfoURL = $MoreInfoURL
-                        Language    = $Language
-                        Title       = $Title
-                        Description = $Description
-                    }
+                    $k = $rule.$PropertyName
+                    $v = $rule.$PropertyValue
+                }
+                $params = @{
+                    SettingName = $k
+                    Operator    = $Operator
+                    DataType    = $DataType
+                    Operand     = $v
+                    MoreInfoURL = $MoreInfoURL
+                    Language    = $Language
+                    Title       = $Title
+                    Description = $Description
                 }
                 $iccs = New-IntuneCustomComplianceSetting @params
                 $ruleSet.Add($iccs) | Out-Null


### PR DESCRIPTION
1. Added CustomQueryRule to handle hashtables instead of Objects. Common for custom 'baselines'. 
2. Added Null SettingName handling for Custom Compliance queries which return one or more NULL/empty keys. 
3. Updated Get-Help to show flow of CustomQueryRule